### PR TITLE
Initialising checks & jlibtorrent downgrade

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -58,7 +58,7 @@ android {
 }
 
 ext {
-    libtorrentVersion = '1.1.0.23'
+    libtorrentVersion = '1.1.0.22'
 }
 
 dependencies {

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -74,7 +74,7 @@ public class Torrent implements AlertListener {
 
         this.prepareSize = prepareSize;
 
-        torrentHandle.setPriority(Priority.NORMAL.swig());
+        torrentHandle.setPriority(Priority.NORMAL.getSwig());
 
         if (selectedFileIndex == -1)
             setLargestFile();
@@ -91,9 +91,9 @@ public class Torrent implements AlertListener {
         Priority[] priorities = torrentHandle.getPiecePriorities();
         for (int i = 0; i < priorities.length; i++) {
             if (i >= firstPieceIndex && i <= lastPieceIndex) {
-                torrentHandle.piecePriority(i, Priority.NORMAL);
+                torrentHandle.setPiecePriority(i, Priority.NORMAL);
             } else {
-                torrentHandle.piecePriority(i, Priority.IGNORE);
+                torrentHandle.setPiecePriority(i, Priority.IGNORE);
             }
         }
     }
@@ -108,7 +108,7 @@ public class Torrent implements AlertListener {
     }
 
     public File getVideoFile() {
-        return new File(torrentHandle.getSavePath() + "/" + torrentHandle.getTorrentInfo().files().filePath(selectedFileIndex));
+        return new File(torrentHandle.getSavePath() + "/" + torrentHandle.getTorrentInfo().getFiles().getFilePath(selectedFileIndex));
     }
 
     /**
@@ -149,13 +149,13 @@ public class Torrent implements AlertListener {
      */
     public void setSelectedFileIndex(Integer selectedFileIndex) {
         TorrentInfo torrentInfo = torrentHandle.getTorrentInfo();
-        FileStorage fileStorage = torrentInfo.files();
+        FileStorage fileStorage = torrentInfo.getFiles();
 
         if (selectedFileIndex == -1) {
             long highestFileSize = 0;
             int selectedFile = -1;
-            for (int i = 0; i < fileStorage.numFiles(); i++) {
-                long fileSize = fileStorage.fileSize(i);
+            for (int i = 0; i < fileStorage.getNumFiles(); i++) {
+                long fileSize = fileStorage.getFileSize(i);
                 if (highestFileSize < fileSize) {
                     highestFileSize = fileSize;
                     torrentHandle.setFilePriority(selectedFile, Priority.IGNORE);
@@ -167,7 +167,7 @@ public class Torrent implements AlertListener {
             }
             selectedFileIndex = selectedFile;
         } else {
-            for (int i = 0; i < fileStorage.numFiles(); i++) {
+            for (int i = 0; i < fileStorage.getNumFiles(); i++) {
                 if (i == selectedFileIndex) {
                     torrentHandle.setFilePriority(i, Priority.NORMAL);
                 } else {
@@ -225,10 +225,10 @@ public class Torrent implements AlertListener {
      * @return {@link String[]}
      */
     public String[] getFileNames() {
-        FileStorage fileStorage = torrentHandle.getTorrentInfo().files();
-        String[] fileNames = new String[fileStorage.numFiles()];
-        for (int i = 0; i < fileStorage.numFiles(); i++) {
-            fileNames[i] = fileStorage.fileName(i);
+        FileStorage fileStorage = torrentHandle.getTorrentInfo().getFiles();
+        String[] fileNames = new String[fileStorage.getNumFiles()];
+        for (int i = 0; i < fileStorage.getNumFiles(); i++) {
+            fileNames[i] = fileStorage.getFileName(i);
         }
         return fileNames;
     }
@@ -240,26 +240,26 @@ public class Torrent implements AlertListener {
     public void startDownload() {
         if (state == State.STREAMING) return;
         state = State.STARTING;
-        torrentHandle.setPriority(Priority.NORMAL.swig());
+        torrentHandle.setPriority(Priority.NORMAL.getSwig());
 
         List<Integer> indices = new ArrayList<>();
 
         Priority[] priorities = torrentHandle.getPiecePriorities();
         for (int i = 0; i < priorities.length; i++) {
             if (priorities[i] != Priority.IGNORE) {
-                torrentHandle.piecePriority(i, Priority.NORMAL);
+                torrentHandle.setPiecePriority(i, Priority.NORMAL);
             }
         }
 
         for (int i = 0; i < piecesToPrepare; i++) {
             indices.add(lastPieceIndex - i);
-            torrentHandle.piecePriority(lastPieceIndex - i, Priority.SEVEN);
+            torrentHandle.setPiecePriority(lastPieceIndex - i, Priority.SEVEN);
             torrentHandle.setPieceDeadline(lastPieceIndex - i, 1000);
         }
 
         for (int i = 0; i < piecesToPrepare; i++) {
             indices.add(firstPieceIndex + i);
-            torrentHandle.piecePriority(firstPieceIndex + i, Priority.SEVEN);
+            torrentHandle.setPiecePriority(firstPieceIndex + i, Priority.SEVEN);
             torrentHandle.setPieceDeadline(firstPieceIndex + i, 1000);
         }
 
@@ -290,7 +290,7 @@ public class Torrent implements AlertListener {
             torrentHandle.setSequentialDownload(true);
         } else {
             for (int i = firstPieceIndex + piecesToPrepare; i < firstPieceIndex + piecesToPrepare + 5; i++) {
-                torrentHandle.piecePriority(i, Priority.SEVEN);
+                torrentHandle.setPiecePriority(i, Priority.SEVEN);
                 torrentHandle.setPieceDeadline(i, 1000);
             }
         }
@@ -312,11 +312,11 @@ public class Torrent implements AlertListener {
      */
     private void pieceFinished(PieceFinishedAlert alert) {
         if (state == State.STREAMING && hasPieces != null) {
-            hasPieces[alert.pieceIndex() - firstPieceIndex] = true;
+            hasPieces[alert.getPieceIndex() - firstPieceIndex] = true;
 
-            for (int i = alert.pieceIndex() - firstPieceIndex; i < hasPieces.length; i++) {
+            for (int i = alert.getPieceIndex() - firstPieceIndex; i < hasPieces.length; i++) {
                 if (!hasPieces[i]) {
-                    torrentHandle.piecePriority(i + firstPieceIndex, Priority.SEVEN);
+                    torrentHandle.setPiecePriority(i + firstPieceIndex, Priority.SEVEN);
                     torrentHandle.setPieceDeadline(i + firstPieceIndex, 1000);
                     break;
                 }
@@ -325,13 +325,13 @@ public class Torrent implements AlertListener {
             Iterator<Integer> piecesIterator = preparePieces.iterator();
             while (piecesIterator.hasNext()) {
                 int index = piecesIterator.next();
-                if (index == alert.pieceIndex()) {
+                if (index == alert.getPieceIndex()) {
                     piecesIterator.remove();
                 }
             }
 
             if (hasPieces != null) {
-                hasPieces[alert.pieceIndex() - firstPieceIndex] = true;
+                hasPieces[alert.getPieceIndex() - firstPieceIndex] = true;
             }
 
             if (preparePieces.size() == 0) {

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
@@ -55,7 +55,7 @@ public class TorrentStream {
 
     private Session torrentSession;
     private DHT dht;
-    private Boolean initialised = false, isStreaming = false, isCanceled = false;
+    private Boolean initialising = false, initialised = false, isStreaming = false, isCanceled = false;
     private TorrentOptions torrentOptions;
 
     private Torrent currentTorrent;
@@ -88,11 +88,14 @@ public class TorrentStream {
         if (libTorrentThread != null && torrentSession != null) {
             resumeSession();
         } else {
-            if (initialised) {
+            if (initialising || initialised) {
                 if (libTorrentThread != null) {
                     libTorrentThread.interrupt();
                 }
             }
+
+            initialising = true;
+            initialised = false;
 
             libTorrentThread = new HandlerThread(LIBTORRENT_THREAD_NAME);
             libTorrentThread.start();
@@ -108,6 +111,7 @@ public class TorrentStream {
                     dht = new DHT(torrentSession);
                     dht.start();
 
+                    initialising = false;
                     initialised = true;
                 }
             });
@@ -240,7 +244,7 @@ public class TorrentStream {
      * @param torrentUrl {@link String} .torrent or magnet link
      */
     public void startStream(final String torrentUrl) {
-        if (!initialised)
+        if (!initialising && !initialised)
             initialise();
 
         if (libTorrentHandler == null || isStreaming) return;

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
@@ -321,7 +321,7 @@ public class TorrentStream {
                     return;
                 }
 
-                Priority[] priorities = new Priority[torrentInfo.numPieces()];
+                Priority[] priorities = new Priority[torrentInfo.getNumPieces()];
                 for (int i = 0; i < priorities.length; i++) {
                     priorities[i] = Priority.IGNORE;
                 }


### PR DESCRIPTION
I've fixed a couple of problems I've ran into with initialising.

`TorrentStream.initialise` can be called twice when constructing a `TorrentStream` and immediately calling `TorrentStream.startStream`. Although `initialised` is checked at the start of `startStream`, it isn't set to true until `libTorrentThread/libTorrentHandler` has executed the runnable.

The second is that the `streamingThread/streamingHandler` runnable in `TorrentStream.startStream` can be executed before the runnable in `TorrentStream.initialise` has. I've added a latch and the `startStream` runnable now waits until initialisation has completed.

I've also downgraded jlibtorrent due to [#85](https://github.com/frostwire/frostwire-jlibtorrent/issues/85) (this stops this library working on Marshmallow and N).