### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/utils/FileUtils.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/utils/FileUtils.java
@@ -21,7 +21,11 @@ package com.github.se_bastiaan.torrentstream.utils;
 
 import java.io.File;
 
-public class FileUtils {
+public final class FileUtils {
+
+    private FileUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Delete every item below the File location

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/utils/ThreadUtils.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/utils/ThreadUtils.java
@@ -22,8 +22,11 @@ package com.github.se_bastiaan.torrentstream.utils;
 import android.os.Handler;
 import android.os.Looper;
 
-public class ThreadUtils {
+public final class ThreadUtils {
 
+    private ThreadUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
     /**
      * Execute the given {@link Runnable} on the ui thread.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat