### PR TITLE
Multiple quality improvements - squid:HiddenFieldCheck, squid:SwitchLastCaseIsDefaultCheck, squid:S2974

### DIFF
--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -178,25 +178,25 @@ public class Torrent implements AlertListener {
         this.selectedFileIndex = selectedFileIndex;
 
         Priority[] piecePriorities = torrentHandle.getPiecePriorities();
-        int firstPieceIndex = -1;
-        int lastPieceIndex = -1;
+        int firstPieceIndexLocal = -1;
+        int lastPieceIndexLocal = -1;
         for (int i = 0; i < piecePriorities.length; i++) {
             if (piecePriorities[i] != Priority.IGNORE) {
-                if (firstPieceIndex == -1) {
-                    firstPieceIndex = i;
+                if (firstPieceIndexLocal == -1) {
+                    firstPieceIndexLocal = i;
                 }
                 piecePriorities[i] = Priority.IGNORE;
             } else {
-                if (firstPieceIndex != -1 && lastPieceIndex == -1) {
-                    lastPieceIndex = i - 1;
+                if (firstPieceIndexLocal != -1 && lastPieceIndexLocal == -1) {
+                    lastPieceIndexLocal = i - 1;
                 }
             }
         }
 
-        if (lastPieceIndex == -1) {
-            lastPieceIndex = piecePriorities.length - 1;
+        if (lastPieceIndexLocal == -1) {
+            lastPieceIndexLocal = piecePriorities.length - 1;
         }
-        int pieceCount = lastPieceIndex - firstPieceIndex + 1;
+        int pieceCount = lastPieceIndexLocal - firstPieceIndexLocal + 1;
         int pieceLength = torrentHandle.getTorrentInfo().pieceLength();
         int activePieceCount;
         if (pieceLength > 0) {
@@ -214,8 +214,8 @@ public class Torrent implements AlertListener {
             activePieceCount = pieceCount / 2;
         }
 
-        this.firstPieceIndex = firstPieceIndex;
-        this.lastPieceIndex = lastPieceIndex;
+        this.firstPieceIndex = firstPieceIndexLocal;
+        this.lastPieceIndex = lastPieceIndexLocal;
         piecesToPrepare = activePieceCount;
     }
 
@@ -386,6 +386,8 @@ public class Torrent implements AlertListener {
                 break;
             case BLOCK_FINISHED:
                 blockFinished((BlockFinishedAlert) alert);
+                break;
+            default:
                 break;
         }
     }

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentOptions.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentOptions.java
@@ -18,7 +18,7 @@ package com.github.se_bastiaan.torrentstream;
 
 import java.io.File;
 
-public class TorrentOptions {
+public final class TorrentOptions {
 
     protected String saveLocation = "/";
     protected String proxyHost;

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentStream.java
@@ -49,7 +49,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-public class TorrentStream {
+public final class TorrentStream {
 
     private static final String LIBTORRENT_THREAD_NAME = "TORRENTSTREAM_LIBTORRENT", STREAMING_THREAD_NAME = "TORRENTSTREAMER_STREAMING";
     private static TorrentStream sThis;
@@ -107,10 +107,8 @@ public class TorrentStream {
         if (libTorrentThread != null && torrentSession != null) {
             resumeSession();
         } else {
-            if (initialising || initialised) {
-                if (libTorrentThread != null) {
-                    libTorrentThread.interrupt();
-                }
+            if ((initialising || initialised) && libTorrentThread != null) {
+                libTorrentThread.interrupt();
             }
 
             initialising = true;
@@ -294,19 +292,17 @@ public class TorrentStream {
                 currentTorrentUrl = torrentUrl;
 
                 File saveDirectory = new File(torrentOptions.saveLocation);
-                if (!saveDirectory.isDirectory()) {
-                    if (!saveDirectory.mkdirs()) {
-                        for (final TorrentListener listener : listeners) {
-                            ThreadUtils.runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    listener.onStreamError(null, new DirectoryModifyException());
-                                }
-                            });
-                        }
-                        isStreaming = false;
-                        return;
+                if (!saveDirectory.isDirectory() && !saveDirectory.mkdirs()) {
+                    for (final TorrentListener listener : listeners) {
+                        ThreadUtils.runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                listener.onStreamError(null, new DirectoryModifyException());
+                            }
+                        });
                     }
+                    isStreaming = false;
+                    return;
                 }
 
                 torrentSession.removeListener(torrentAddedAlertListener);

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/listeners/TorrentAddedAlertListener.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/listeners/TorrentAddedAlertListener.java
@@ -33,6 +33,8 @@ public abstract class TorrentAddedAlertListener implements AlertListener {
             case TORRENT_ADDED:
                 torrentAdded((TorrentAddedAlert) alert);
                 break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
squid:HiddenFieldCheck - Local variables should not shadow class fields
squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat