### PR TITLE
Add a blocking InputStream for videos

### DIFF
--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (C) 2015-2016 Sébastiaan (github.com/se-bastiaan)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -57,6 +58,8 @@ public class Torrent implements AlertListener {
     private List<Integer> preparePieces;
     private Boolean[] hasPieces;
 
+    private List<WeakReference<TorrentInputStream>> torrentStreamReferences;
+
     private State state = State.RETRIEVING_META;
 
     private final TorrentHandle torrentHandle;
@@ -78,6 +81,8 @@ public class Torrent implements AlertListener {
         this.listener = listener;
 
         this.prepareSize = prepareSize;
+
+        torrentStreamReferences = new ArrayList<>();
 
         if (selectedFileIndex == -1) {
             setLargestFile();
@@ -123,7 +128,10 @@ public class Torrent implements AlertListener {
      */
     public InputStream getVideoStream() throws FileNotFoundException {
         File file = getVideoFile();
-        return new TorrentInputStream(this, new FileInputStream(file));
+        TorrentInputStream inputStream = new TorrentInputStream(this, new FileInputStream(file));
+        torrentStreamReferences.add(new WeakReference<>(inputStream));
+
+        return inputStream;
     }
 
     /**
@@ -289,6 +297,8 @@ public class Torrent implements AlertListener {
         double blockCount = indices.size() * torrentInfo.pieceLength() / status.blockSize();
 
         progressStep = 100 / blockCount;
+
+        torrentStreamReferences.clear();
 
         torrentHandle.resume();
 
@@ -499,6 +509,19 @@ public class Torrent implements AlertListener {
             default:
                 break;
         }
-    }
 
+        Iterator<WeakReference<TorrentInputStream>> i = torrentStreamReferences.iterator();
+
+        while (i.hasNext()) {
+            WeakReference<TorrentInputStream> reference = i.next();
+            TorrentInputStream inputStream = reference.get();
+
+            if (inputStream == null) {
+                i.remove();
+                continue;
+            }
+
+            inputStream.alert(alert);
+        }
+    }
 }

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (C) 2015-2016 Sébastiaan (github.com/se-bastiaan)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -29,6 +29,9 @@ import com.frostwire.jlibtorrent.alerts.PieceFinishedAlert;
 import com.github.se_bastiaan.torrentstream.listeners.TorrentListener;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -110,6 +113,17 @@ public class Torrent implements AlertListener {
 
     public File getVideoFile() {
         return new File(torrentHandle.savePath() + "/" + torrentHandle.torrentFile().files().filePath(selectedFileIndex));
+    }
+
+    /**
+     * Get an InputStream for the video file.
+     * Read is be blocked until the requested piece(s) is downloaded.
+     *
+     * @return {@link InputStream}
+     */
+    public InputStream getVideoStream() throws FileNotFoundException {
+        File file = getVideoFile();
+        return new TorrentInputStream(this, new FileInputStream(file));
     }
 
     /**

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
@@ -1,0 +1,82 @@
+package com.github.se_bastiaan.torrentstream;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class TorrentInputStream extends FilterInputStream {
+    private Torrent torrent;
+    private boolean interrupted;
+    private long location;
+
+    TorrentInputStream(Torrent torrent, InputStream inputStream) {
+        super(inputStream);
+
+        this.torrent = torrent;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        synchronized (this) {
+            interrupted = true;
+        }
+
+        super.finalize();
+    }
+
+    private synchronized boolean waitForPiece(long offset) {
+        while (!Thread.currentThread().isInterrupted() && !interrupted) {
+            try {
+                if (torrent.hasBytes(offset)) {
+                    return true;
+                }
+
+                wait(10);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        if (!waitForPiece(location)) {
+            return -1;
+        }
+
+        location++;
+
+        return super.read();
+    }
+
+    @Override
+    public synchronized int read(byte[] buffer, int offset, int length) throws IOException {
+        int pieceLength = torrent.getTorrentHandle().torrentFile().pieceLength();
+
+        for (int i = 0; i < length; i += pieceLength) {
+            if (!waitForPiece(location + i)) {
+                return -1;
+            }
+        }
+
+        location += length;
+
+        return super.read(buffer, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (this) {
+            interrupted = true;
+        }
+
+        super.close();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+}

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
@@ -23,6 +23,7 @@ class TorrentInputStream extends FilterInputStream implements AlertListener {
     protected void finalize() throws Throwable {
         synchronized (this) {
             stopped = true;
+            notifyAll();
         }
 
         super.finalize();
@@ -74,6 +75,7 @@ class TorrentInputStream extends FilterInputStream implements AlertListener {
     public void close() throws IOException {
         synchronized (this) {
             stopped = true;
+            notifyAll();
         }
 
         super.close();

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/TorrentInputStream.java
@@ -76,6 +76,12 @@ class TorrentInputStream extends FilterInputStream {
     }
 
     @Override
+    public synchronized long skip(long n) throws IOException {
+        location += n;
+        return super.skip(n);
+    }
+
+    @Override
     public boolean markSupported() {
         return false;
     }


### PR DESCRIPTION
I've added an InputStream filter via `Torrent.getVideoStream()` which blocks reading the video file until the requested pieces are downloaded.

I've used this to stream the video from an HTTP range request, this prevents sending data which hasn't yet been downloaded to the video player (VLC doesn't like that).